### PR TITLE
Align article pages with the home board layout

### DIFF
--- a/_includes/board-panel.html
+++ b/_includes/board-panel.html
@@ -1,0 +1,30 @@
+{%- comment -%}
+The board's left panel: chrome at the top, split-flap tiles in the middle, a
+caption underneath. Every page type renders the same panel — only the tiles
+change — so nothing shifts under you when you move between the board and an
+entry.
+
+Decorative: the tiles repeat a heading the page already carries, and the clock
+and caption are board dressing, so the whole panel is aria-hidden.
+
+Usage:
+  {% assign lines = page.title | split: ' ' %}
+  {% include board-panel.html lines=lines tiles_class="post-title-container" %}
+{%- endcomment -%}
+<div class="left-column" aria-hidden="true">
+  <div class="board-head">
+    <span class="board-dot"></span>
+    <span class="board-title">{{ site.board.title }}</span>
+    <span class="board-clock" data-clock>--:--</span>
+  </div>
+
+  <div class="{{ include.tiles_class | default: 'initials' }}">
+    {% for line in include.lines %}
+    <div class="tile-line">{% include flip-line.html text=line %}</div>
+    {% endfor %}
+  </div>
+
+  <p class="board-caption">
+    {{ site.posts.size }} {% if site.posts.size == 1 %}ENTRY{% else %}ENTRIES{% endif %} ON THE BOARD · LIVE
+  </p>
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,16 +4,10 @@ layout: default
 {% assign topic = site.board.topics[page.topic] %}
 <div class="two-column-layout">
 
-  <div class="left-column left-column--article" aria-hidden="true">
-    <div class="post-title-container">
-      {% assign title_words = page.title | split: ' ' %}
-      {% for word in title_words %}
-      <div class="title-line">{% include flip-line.html text=word %}</div>
-      {% endfor %}
-    </div>
-  </div>
+  {% assign title_words = page.title | split: ' ' %}
+  {% include board-panel.html lines=title_words tiles_class="post-title-container" %}
 
-  <div class="right-column right-column--article">
+  <div class="right-column">
     <div class="post-article-container">
       <div class="post-meta">
         <a href="{{ "/" | prepend: site.baseurl }}" class="back-link"><span aria-hidden="true">←</span> <span class="sr-only">Back to </span>{{ site.board.title }}</a>

--- a/_scss/layout/post.scss
+++ b/_scss/layout/post.scss
@@ -175,3 +175,36 @@ p {
 		border-radius: 5px;
 	}
 }
+
+//=========================================
+// Responsive
+//=========================================
+
+// Must live here rather than in layout/two-column.scss: this partial is
+// imported last, so an equal-specificity rule there loses the cascade to the
+// defaults above no matter what the media query says.
+@media (max-width: 768px) {
+	// Too narrow to sit the back link and the filing line on one row; stacked,
+	// they keep the left edge the rest of the column reads from.
+	.post-meta {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 1rem;
+	}
+
+	.post-content {
+		font-size: 1rem;
+
+		h1 {
+			font-size: 2rem;
+		}
+
+		h2 {
+			font-size: 1.5rem;
+		}
+
+		h3 {
+			font-size: 1.25rem;
+		}
+	}
+}

--- a/_scss/layout/two-column.scss
+++ b/_scss/layout/two-column.scss
@@ -16,6 +16,11 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  // A title long enough to outgrow the panel would otherwise centre its
+  // overflow and push the board head off the top of the screen. `safe` pins the
+  // start edge in that case only — identical to plain centring when it fits.
+  // The unprefixed declaration above is the fallback for browsers that drop it.
+  justify-content: safe center;
   gap: 1.5rem;
   padding: 2.75rem 2.5rem;
   background-color: $board-panel;
@@ -77,6 +82,9 @@
   }
 }
 
+// The tile block — the name on the home board, the title on an entry. Both sit
+// in the same slot of the same panel, so the first line lands on the same left
+// edge and the block centres on the same midline whichever page you're on.
 .initials,
 .post-title-container {
   display: flex;
@@ -85,17 +93,14 @@
   gap: 0.625rem;
 }
 
-// The home panel stacks board chrome around a left-aligned name. The article
-// panel holds only the title, which the design centres in the panel — lines
-// stay left-aligned to each other, it's the block that centres.
-.left-column--article {
-  align-items: center;
-}
-
-.name-line,
-.title-line {
+// A word longer than the panel wraps onto a second row of flaps rather than
+// running under the seam — post titles aren't length-controlled the way the
+// name is.
+.tile-line {
   display: flex;
+  flex-wrap: wrap;
   gap: 6px;
+  max-width: 100%;
   perspective: 900px;
   line-height: 1;
 }
@@ -129,6 +134,9 @@
   }
 }
 
+// Centring applies to both page types. An article taller than the viewport
+// grows the column past its min-height, at which point centring is a no-op and
+// the prose reads from the top as usual.
 .right-column {
   flex: 1;
   padding: 4rem 3.5rem;
@@ -136,11 +144,6 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-}
-
-// The board sits centred in its column; an article reads from the top.
-.right-column--article {
-  justify-content: flex-start;
 }
 
 .posts-container {
@@ -169,14 +172,7 @@
     align-items: center;
   }
 
-  // Stacked, the title sits above the article rather than beside it — align it
-  // to the same left edge as everything else instead of centring.
-  .left-column--article {
-    align-items: flex-start;
-  }
-
-  .name-line,
-  .title-line {
+  .tile-line {
     display: inline-flex !important;
     width: auto !important;
     margin: 0 !important;
@@ -192,27 +188,5 @@
     // Vertical centring is for the full-height desktop column; once stacked it
     // just strands the board halfway down the screen.
     justify-content: flex-start;
-  }
-
-  .post-meta {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1rem;
-  }
-
-  .post-content {
-    font-size: 1rem;
-
-    h1 {
-      font-size: 2rem;
-    }
-
-    h2 {
-      font-size: 1.5rem;
-    }
-
-    h3 {
-      font-size: 1.25rem;
-    }
   }
 }

--- a/index.html
+++ b/index.html
@@ -3,24 +3,8 @@ layout: default
 ---
 <div class="two-column-layout">
 
-  <div class="left-column" aria-hidden="true">
-    <div class="board-head">
-      <span class="board-dot"></span>
-      <span class="board-title">{{ site.board.title }}</span>
-      <span class="board-clock" data-clock>--:--</span>
-    </div>
-
-    <div class="initials">
-      {% assign name_lines = "MICHAEL,BROWN" | split: "," %}
-      {% for line in name_lines %}
-      <div class="name-line">{% include flip-line.html text=line %}</div>
-      {% endfor %}
-    </div>
-
-    <p class="board-caption">
-      {{ site.posts.size }} {% if site.posts.size == 1 %}ENTRY{% else %}ENTRIES{% endif %} ON THE BOARD · LIVE
-    </p>
-  </div>
+  {% assign name_lines = "MICHAEL,BROWN" | split: "," %}
+  {% include board-panel.html lines=name_lines %}
 
   <div class="right-column">
     <div class="posts-container">


### PR DESCRIPTION
Article pages and the home page laid out their left panel differently, so moving between the two shifted the split-flap title sideways and stripped the panel's chrome.

## The mismatch

Measured at 1440×900:

| | home | article (before) |
|---|---|---|
| tile block left edge | x=40 | x=221 |
| board head / caption | present | absent |
| right column content | centred (y=365) | top (y=64) |

The article panel centred its title horizontally and held nothing else.

## Changes

- **New `_includes/board-panel.html`** renders the left panel once — head (lamp, ARRIVALS, clock), tiles, caption. Both `index.html` and `_layouts/post.html` include it, so only the flaps change between page types.
- **Dropped `.left-column--article`** (`align-items: center`) and **`.right-column--article`** (`justify-content: flex-start`). Short entries now centre like the board; longer ones outgrow the column, at which point centring is a no-op and prose reads from the top as before.
- **`.tile-line` gets `flex-wrap`** so a word wider than the panel wraps onto a second row of flaps instead of running under the seam — post titles aren't length-controlled the way `MICHAEL BROWN` is.
- **`justify-content: safe center`** on the panel so a very long title pushes its overflow off the bottom rather than shoving the board head off the top. Identical to plain centring whenever the content fits; the unprefixed declaration stays as a fallback.

## Separate fix included

The mobile `.post-meta` and `.post-content` overrides lived in `two-column.scss`, which is imported *before* `post.scss` — so the desktop defaults won on equal specificity and those rules never applied at any width. On phones the filing line stayed centred against a left-aligned column and prose stayed at 1.375rem. Moved them into `post.scss`, next to the rules they cancel (same pattern the reduced-motion override in `board.scss` already documents).

This is a behaviour change beyond the alignment fix — easy to drop as its own hunk if you'd rather keep it separate.

## Verification

Built locally and measured element boxes with a headless browser at 1440/1024/390 widths, plus a 620px-tall window with an 8-word test title.

- After: tiles at x=40 on both page types, tile-block midline 446 on both, right-column content midline 450 on both.
- The home page renders **pixel-identical** to before — every measured box unchanged.
- No horizontal overflow at any tested width (`scrollWidth == clientWidth`).

## Known trade-off

The tile *block* centres on the same midline on every page, but a 3-word title is taller than the 2-line name, so its first row starts ~32px higher than the home page's. Pinning the first row instead would need a magic offset tied to the name's height and would push 6+ word titles off the panel bottom, so centring won.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhWZJvWLXLwqJCNRsZT5Ke

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhWZJvWLXLwqJCNRsZT5Ke)_